### PR TITLE
Add return in get user error handling

### DIFF
--- a/handler_user.go
+++ b/handler_user.go
@@ -141,6 +141,7 @@ func (apiCfg *apiConfig) handlerGetUserFromCookie(w http.ResponseWriter, r *http
 	user, err := apiCfg.DB.GetUserByID(r.Context(), userID)
 	if err != nil {
 		respondWithError(w, 404, fmt.Sprintf("User not found: %v", err))
+		return
 	}
 	respondWithJSON(w, 200, databaseUserToUser(user))
 }


### PR DESCRIPTION
Prevents empty user from being returned which throws a client error of unexpected empty whitespace in at the beggining of the fetched json